### PR TITLE
Update to latest fusionauth go client

### DIFF
--- a/fusionauth/resource_fusionauth_idp_samlv2.go
+++ b/fusionauth/resource_fusionauth_idp_samlv2.go
@@ -283,25 +283,27 @@ func buildIDPSAMLv2(data *schema.ResourceData) SAMLIdentityProviderBody {
 	s := fusionauth.SAMLv2IdentityProvider{
 		ButtonImageURL: data.Get("button_image_url").(string),
 		ButtonText:     data.Get("button_text").(string),
-		BaseIdentityProvider: fusionauth.BaseIdentityProvider{
-			Debug:      data.Get("debug").(bool),
-			Enableable: buildEnableable("enabled", data),
-			LambdaConfiguration: fusionauth.ProviderLambdaConfiguration{
-				ReconcileId: data.Get("lambda_reconcile_id").(string),
+		BaseSAMLv2IdentityProvider: fusionauth.BaseSAMLv2IdentityProvider{
+			BaseIdentityProvider: fusionauth.BaseIdentityProvider{
+				Debug:      data.Get("debug").(bool),
+				Enableable: buildEnableable("enabled", data),
+				LambdaConfiguration: fusionauth.ProviderLambdaConfiguration{
+					ReconcileId: data.Get("lambda_reconcile_id").(string),
+				},
+				Name:            data.Get("name").(string),
+				Type:            fusionauth.IdentityProviderType_SAMLv2,
+				LinkingStrategy: fusionauth.IdentityProviderLinkingStrategy(data.Get("linking_strategy").(string)),
 			},
-			Name:            data.Get("name").(string),
-			Type:            fusionauth.IdentityProviderType_SAMLv2,
-			LinkingStrategy: fusionauth.IdentityProviderLinkingStrategy(data.Get("linking_strategy").(string)),
+			EmailClaim:          data.Get("email_claim").(string),
+			KeyId:               data.Get("key_id").(string),
+			UseNameIdForEmail:   data.Get("use_name_for_email").(bool),
 		},
 		Domains:             handleStringSlice("domains", data),
-		EmailClaim:          data.Get("email_claim").(string),
 		IdpEndpoint:         data.Get("idp_endpoint").(string),
-		KeyId:               data.Get("key_id").(string),
 		NameIdFormat:        data.Get("name_id_format").(string),
 		PostRequest:         data.Get("post_request").(bool),
 		RequestSigningKeyId: data.Get("request_signing_key").(string),
 		SignRequest:         data.Get("sign_request").(bool),
-		UseNameIdForEmail:   data.Get("use_name_for_email").(bool),
 		XmlSignatureC14nMethod: fusionauth.CanonicalizationMethod(
 			data.Get("xml_signature_canonicalization_method").(string),
 		),

--- a/fusionauth/resource_fusionauth_idp_samlv2_idp_initiated.go
+++ b/fusionauth/resource_fusionauth_idp_samlv2_idp_initiated.go
@@ -214,20 +214,22 @@ func updateIDPSAMLv2IdPInitiated(_ context.Context, data *schema.ResourceData, i
 
 func buildIDPSAMLv2IdPInitiated(data *schema.ResourceData) SAMLIDPInitiatedIdentityProviderBody {
 	s := fusionauth.SAMLv2IdPInitiatedIdentityProvider{
-		BaseIdentityProvider: fusionauth.BaseIdentityProvider{
-			Debug:      data.Get("debug").(bool),
-			Enableable: buildEnableable("enabled", data),
-			LambdaConfiguration: fusionauth.ProviderLambdaConfiguration{
-				ReconcileId: data.Get("lambda_reconcile_id").(string),
+		BaseSAMLv2IdentityProvider: fusionauth.BaseSAMLv2IdentityProvider{
+			BaseIdentityProvider: fusionauth.BaseIdentityProvider{
+				Debug:      data.Get("debug").(bool),
+				Enableable: buildEnableable("enabled", data),
+				LambdaConfiguration: fusionauth.ProviderLambdaConfiguration{
+					ReconcileId: data.Get("lambda_reconcile_id").(string),
+				},
+				Name:            data.Get("name").(string),
+				Type:            fusionauth.IdentityProviderType_SAMLv2IdPInitiated,
+				LinkingStrategy: fusionauth.IdentityProviderLinkingStrategy(data.Get("linking_strategy").(string)),
 			},
-			Name:            data.Get("name").(string),
-			Type:            fusionauth.IdentityProviderType_SAMLv2IdPInitiated,
-			LinkingStrategy: fusionauth.IdentityProviderLinkingStrategy(data.Get("linking_strategy").(string)),
+			EmailClaim:        data.Get("email_claim").(string),
+			KeyId:             data.Get("key_id").(string),
+			UseNameIdForEmail: data.Get("use_name_for_email").(bool),
 		},
-		EmailClaim:        data.Get("email_claim").(string),
 		Issuer:            data.Get("issuer").(string),
-		KeyId:             data.Get("key_id").(string),
-		UseNameIdForEmail: data.Get("use_name_for_email").(bool),
 	}
 	s.ApplicationConfiguration = buildIDPSAMLv2IdPInitiatedAppConfig("application_configuration", data)
 	s.TenantConfiguration = buildTenantConfiguration(data)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gpsinsight/terraform-provider-fusionauth
 go 1.18
 
 require (
-	github.com/FusionAuth/go-client v0.0.0-20221122022225-f59b115f1ce4
+	github.com/FusionAuth/go-client v0.0.0-20230313185644-4aefe6d7b4c8
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.14.0

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/FusionAuth/go-client v0.0.0-20221122022225-f59b115f1ce4 h1:CbUKbP2hpU1hCthmn7cUnbdwO54HCZwTYedBVacZ6R4=
 github.com/FusionAuth/go-client v0.0.0-20221122022225-f59b115f1ce4/go.mod h1:SyRrXMJAzMVQLiJjKfQUR59dRI3jPyZv+BXIZ//HwE4=
+github.com/FusionAuth/go-client v0.0.0-20230313185644-4aefe6d7b4c8 h1:7D/Sn/pVYCzWORTFNu8POFO9zWLv+KUQ0ry/P/vqOXw=
+github.com/FusionAuth/go-client v0.0.0-20230313185644-4aefe6d7b4c8/go.mod h1:SyRrXMJAzMVQLiJjKfQUR59dRI3jPyZv+BXIZ//HwE4=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=


### PR DESCRIPTION
In order to [add support for the OAuth2TwoFactorEnable and Oauth2TwoFactorEnableComplete theme templates](https://github.com/gpsinsight/terraform-provider-fusionauth/pull/166) that are included in more recent versions of FusionAuth we must also update the FusionAuth go client that is being consumed. However, as mentioned [here](https://github.com/gpsinsight/terraform-provider-fusionauth/pull/166#issuecomment-1439374539) the [latest version of the go client](https://pkg.go.dev/github.com/FusionAuth/go-client/pkg/fusionauth) is not compatible with the current terraform provider codebase.

This pull request pulls in the latest version of the FusionAuth go client and then makes the minimal changes required to satisfy compilation against the updated interfaces. Adding a new theme with a full list of templates including the two mentioned above is now possible as well. This makes no guarantee that the `buildIDPSAMLv2` and `buildIDPSAMLv2IdPInitiated` actually function, however.